### PR TITLE
virtio-rng.c: fix logical not only applied to lhs of comparison

### DIFF
--- a/hw/virtio/virtio-rng.c
+++ b/hw/virtio/virtio-rng.c
@@ -149,7 +149,7 @@ static void virtio_rng_device_realize(DeviceState *dev, Error **errp)
     VirtIORNG *vrng = VIRTIO_RNG(dev);
     Error *local_err = NULL;
 
-    if (!vrng->conf.period_ms > 0) {
+    if (vrng->conf.period_ms <= 0) {
         error_setg(errp, "'period' parameter expects a positive integer");
         return;
     }


### PR DESCRIPTION
The comparison was wrong, since the precedence of operator '!' in C is higher than the precendence of '>'. This code even refuses to compile with gcc-5.2. The bug has already been fixed upstream in this commit https://github.com/qemu/qemu/commit/a3a292c420d2fec3c07a7ca56fbb064cd57a298a