### PR TITLE
Error handling: DTB model has no memory node

### DIFF
--- a/hw/microblaze/microblaze_generic_fdt.c
+++ b/hw/microblaze/microblaze_generic_fdt.c
@@ -316,6 +316,13 @@ microblaze_generic_fdt_init(MachineState *machine)
     ram_kernel_base = object_property_get_int(OBJECT(main_mem), "addr", NULL);
     ram_kernel_size = object_property_get_int(OBJECT(main_mem), "size", NULL);
 
+    if ((int64_t)ram_kernel_size < 0) {
+        error_report("dtb files has no memory node");
+        error_report("the QEMU model assumes that external memory is attached,"
+                     " caching is enabled and MMU is enabled");
+        exit(1);
+    }
+
     if (!memory_region_is_mapped(main_mem)) {
         /* If the memory region is not mapped, map it here.
          * It has to be mapped somewhere, so guess that the base address

--- a/include/qom/object.h
+++ b/include/qom/object.h
@@ -935,7 +935,7 @@ void object_property_set_int(Object *obj, int64_t value,
  * @name: the name of the property
  * @errp: returns an error if this function fails
  *
- * Returns: the value of the property, converted to an integer, or NULL if
+ * Returns: the value of the property, converted to an integer, or negative if
  * an error occurs (including when the property value is not an integer).
  */
 int64_t object_property_get_int(Object *obj, const char *name,


### PR DESCRIPTION
Hello,
We just have been in contact with Xilinx support because we ran into something which appeared to be an issue in QEMU. Turned out that the issue in fact was our hardware model (HDF,DTB file), however I think the error handling for this could be improved because the error message was misleading.

So as a background: We've started to create a hardware model with the example project. To reproduce go in Vivado 2015.4.1, select ‘File->Open Example Project’. In the wizard, for ‘Select Project Template’, select ‘Base Microblaze’. Create a Hello World project in the Xilinx SDK for this hardware. Compile a DTB file from the HDF file. Run QEMU and it will come back with:

```--------------------------------------------------------------------
Xilinx QEMU Jan 11 2016 10:57:14.
--------------------------------------------------------------------
Bad ram offset 0
7600 Aborted                 (core dumped) $home/qemu/microblazeel-softmmu/qemu-system-microblazeel ...
```
This lead me to believe that something is wrong with how we are loading the image/ELF file. With this pull request we try to propose a better error message. I basically put into the explanation which we got from Xilinx support. Hope this pull request turns out to be useful.

Best regards
Christian