### PR TITLE
Makefile: Fix build/install support for flash-stripe.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,13 +224,18 @@ qemu-io$(EXESUF): qemu-io.o $(block-obj-y) libqemuutil.a libqemustub.a
 qemu-bridge-helper$(EXESUF): qemu-bridge-helper.o
 
 util/qemu-nand-creator$(EXESUF): util/qemu-nand-creator.o
-util/flash-stripe$(EXESUF):
-	gcc $(SRC_PATH)/util/flash-stripe.c -o util/flash-stripe-be -DFLASH_STRIPE_BE
-	gcc $(SRC_PATH)/util/flash-stripe.c -o util/flash-unstripe-be -DFLASH_STRIPE_BE -DUNSTRIPE
-	gcc $(SRC_PATH)/util/flash-stripe.c -o util/flash-stripe-be-bw -DFLASH_STRIPE_BE -DFLASH_STRIPE_BW
-	gcc $(SRC_PATH)/util/flash-stripe.c -o util/flash-unstripe-be-bw -DFLASH_STRIPE_BE -DUNSTRIPE -DFLASH_STRIPE_BW
-	gcc $(SRC_PATH)/util/flash-stripe.c -o util/flash-stripe-bw -DFLASH_STRIPE_BW
-	gcc $(SRC_PATH)/util/flash-stripe.c -o util/flash-unstripe-bw -DUNSTRIPE -DFLASH_STRIPE_BW
+util/flash-stripe-be$(EXESUF): util/flash-stripe.c
+	$(CC) $< -o $@ -DFLASH_STRIPE_BE
+util/flash-unstripe-be$(EXESUF): util/flash-stripe.c
+	$(CC) $< -o $@ -DFLASH_STRIPE_BE -DUNSTRIPE
+util/flash-stripe-be-bw$(EXESUF): util/flash-stripe.c
+	$(CC) $< -o $@ -DFLASH_STRIPE_BE -DFLASH_STRIPE_BW
+util/flash-unstripe-be-bw$(EXESUF): util/flash-stripe.c
+	$(CC) $< -o $@ -DFLASH_STRIPE_BE -DUNSTRIPE -DFLASH_STRIPE_BW
+util/flash-stripe-bw$(EXESUF): util/flash-stripe.c
+	$(CC) $< -o $@ -DFLASH_STRIPE_BW
+util/flash-unstripe-bw$(EXESUF): util/flash-stripe.c
+	$(CC) $< -o $@ -DUNSTRIPE -DFLASH_STRIPE_BW
 
 fsdev/virtfs-proxy-helper$(EXESUF): fsdev/virtfs-proxy-helper.o fsdev/virtio-9p-marshal.o libqemuutil.a libqemustub.a
 fsdev/virtfs-proxy-helper$(EXESUF): LIBS += -lcap

--- a/configure
+++ b/configure
@@ -4175,7 +4175,12 @@ if test "$want_tools" = "yes" ; then
   tools="qemu-img\$(EXESUF) qemu-io\$(EXESUF) $tools"
   if [ "$linux" = "yes" -o "$bsd" = "yes" -o "$solaris" = "yes" ] ; then
     tools="qemu-nbd\$(EXESUF) $tools"
-    tools="$tools util/flash-stripe\$(EXESUF)"
+    tools="$tools util/flash-stripe-be\$(EXESUF)"
+    tools="$tools util/flash-unstripe-be\$(EXESUF)"
+    tools="$tools util/flash-stripe-be-bw\$(EXESUF)"
+    tools="$tools util/flash-unstripe-be-bw\$(EXESUF)"
+    tools="$tools util/flash-stripe-bw\$(EXESUF)"
+    tools="$tools util/flash-unstripe-bw\$(EXESUF)"
     tools="$tools util/qemu-nand-creator\$(EXESUF) "
   fi
 fi


### PR DESCRIPTION
Hi guys,
after 40dc93e448732d commit, the "make install" command fails in the following way:
`
install -d -m 0755 "/home/stefano/usr/qemu-xilinx//bin"
libtool --quiet --mode=install install -c -m 0755 qemu-ga qemu-nbd qemu-img qemu-io  util/flash-stripe util/qemu-nand-creator  fsdev/virtfs-proxy-helper "/home/stefano/usr/qemu-xilinx//bin"
install: cannot stat 'util/flash-stripe': No such file or directory
make: *** [install] Error 1
`

This pull request fixes this issue, adding a target for each utility generated in the Makefile.

Best regards,
Stefano Garzarella