### PR TITLE
Fixes for string truncations reported by gcc 8.2

### DIFF
--- a/hw/ppc/e500.c
+++ b/hw/ppc/e500.c
@@ -277,12 +277,12 @@ static int ppce500_load_device_tree(MachineState *machine,
     int i;
     char compatible_sb[] = "fsl,mpc8544-immr\0simple-bus";
     char soc[128];
-    char mpic[128];
+    char mpic[256];
     uint32_t mpic_ph;
     uint32_t msi_ph;
-    char gutil[128];
+    char gutil[256];
     char pci[128];
-    char msi[128];
+    char msi[256];
     uint32_t *pci_map = NULL;
     int len;
     uint32_t pci_ranges[14] =


### PR DESCRIPTION
The tree can not currently be built with gcc 8.2.1 due to warnings about buffer truncations. The warnings are unlikely to cause real problems, but they need to be fixed anyway, as they are treated as errors.

I'm not sure which of these qualify as upstream material though.