### PR TITLE
Missing Terminator (Null Character) in MDIO Slave Interface

### DIFF
--- a/hw/mdio/core.c
+++ b/hw/mdio/core.c
@@ -152,6 +152,7 @@ static const TypeInfo mdio_slave_info = {
     .class_init = mdio_slave_class_init,
     .interfaces = (InterfaceInfo []) {
         {TYPE_FDT_GENERIC_MMAP},
+        { },
     },
 };
 


### PR DESCRIPTION
When the qom is initialized, it seems to go through each type (in this case the MDIO Slave Interface) and in qom/object.c::type_new() it assigns each `info->interfaces[i].type` to `ti->interfaces[i].typename` , so long as the interfaces and type for the info object are not NULL. 

Without this NULL character included in the interfaces for the MDIO Slave Interface, the source code will compile without any errors but will segmentation fault when executed on an ARM processor. I used GDB to run the aarch64-softmmu binary after compiling it and traced the source of the seg fault back to the creation of the mdio slave interface type. 

After passing in the expected TYPE_FDT_GENERIC_MMAP it did not return from type_new() but instead passed in unexpected values leading to a memory access violation when the strdup in type_new() was attempting to assign the value of `info->interfaces[i].type` to `ti->interfaces[i].typename`.

Ending interfaces with a null character seems to be the general convention of other types within the qemu source code, and after adding and building the binary did not seg fault on ARM. It is worth noting that I attempted this on an x86 processor and never saw any seg faults related to this, and I assume it must be some nuance of the ARMv8 architecture. 