### PR TITLE
Fix "no member named 'sem' in 'struct QemuSemaphore'" on macOS

### DIFF
--- a/hw/core/remote-port.c
+++ b/hw/core/remote-port.c
@@ -493,7 +493,11 @@ static void rp_pt_handover_pkt(RemotePort *s, RemotePortDynPkt *dpkt)
 #ifndef _WIN32
                 int sval;
 
+#ifndef CONFIG_SEM_TIMEDWAIT
+                sval = s->rx_queue.sem.count;
+#else
                 sem_getvalue(&s->rx_queue.sem.sem, &sval);
+#endif
                 qemu_log("semwait: %d rpos=%u wpos=%u\n", sval,
                          s->rx_queue.rpos, s->rx_queue.wpos);
 #endif


### PR DESCRIPTION
Not sure if it's the right way to solve it, looking forward to some feedback.

Closes #48