### PR TITLE
Fix exceute arguments from event_id to event-id and time_ns to time-ns

### DIFF
--- a/scripts/qmp/fault_injection.py
+++ b/scripts/qmp/fault_injection.py
@@ -79,8 +79,8 @@ class FaultInjectionFramework(qmp.QEMUMonitorProtocol):
                 self.print_v(ev, 2)
                 if ev['event'] == 'FAULT_EVENT':
                     data = ev['data']
-                    self.qemu_time = data['time_ns'];
-                    self.callback[data['event_id']]()
+                    self.qemu_time = data['time-ns'];
+                    self.callback[data['event-id']]()
                     self.cont()
                 elif ev['event'] == 'SHUTDOWN':
                     shutdown_evt = True
@@ -100,8 +100,8 @@ class FaultInjectionFramework(qmp.QEMUMonitorProtocol):
         self.callback[elt] = cb
         self.time_print('Notify %s in %sns' % (cb, time_ns))
         qmpcmd = {'execute': 'trigger_event',
-                  'arguments': {'event_id': elt,
-                                'time_ns': time_ns}}
+                  'arguments': {'event-id': elt,
+                                'time-ns': time_ns}}
         self.send(qmpcmd)
 
     def write(self, address, value, size, cpu, debug = False):


### PR DESCRIPTION
Hello, 

I was testing notify functionality of fault_injection, then I have noticed the callback function is not called. After investigation of the issue, I have seen these two errors are printed
![image](https://github.com/user-attachments/assets/b442bad0-e050-42ef-b125-b409ba9b1744)

![image (5)](https://github.com/user-attachments/assets/fd5fb93a-e1fe-4619-81a6-1b9d78e5a146)
 Then I have tried to fix it and with the following changes, it was working properly.

Best regards,