### PR TITLE
allow setting registers via command line.

### DIFF
--- a/hw/core/generic-loader.c
+++ b/hw/core/generic-loader.c
@@ -56,6 +56,19 @@ static void generic_loader_reset(void *opaque)
             cc->set_pc(s->cpu, s->addr);
         }
     }
+    
+    for (int i = 0; i < 31; i++) {
+        if (s->has_register_defaults[i]) {
+            CPUClass *cc = CPU_GET_CLASS(s->cpu);
+            uint8_t buf[sizeof(uint64_t)];
+            memcpy(buf, &s->register_defaults[i], sizeof(uint64_t));
+            if (cc && cc->gdb_write_register) {
+                cc->gdb_write_register(s->cpu, buf, i);
+            }
+        }
+    }
+
+
 
     if (s->data_len) {
         MemTxAttrs attrs = { .unspecified = 0,
@@ -186,6 +199,18 @@ static void generic_loader_realize(DeviceState *dev, Error **errp)
         s->data = cpu_to_le64(s->data);
     }
 
+    /* Store the CPU register default if specified */
+    if (s->reg) {
+        int reg_num;
+        if (sscanf(s->reg, "r%d", &reg_num) == 1 && reg_num >= 0 && reg_num < 31) {
+            s->register_defaults[reg_num] = s->data;
+            s->has_register_defaults[reg_num] = true;
+        } else {
+            error_setg(errp, "Unsupported register: %s", s->reg);
+            return;
+        }
+    }
+
     /* Xilinx: If qdev_hotplug is set then the machine has already been
      * created. This means we are hot-plugging a device. We need to forefully
      * call the reset function to ensure the operation completes.
@@ -207,6 +232,7 @@ static Property generic_loader_props[] = {
     DEFINE_PROP_BOOL("data-be", GenericLoaderState, data_be, false),
     DEFINE_PROP_UINT32("cpu-num", GenericLoaderState, cpu_num, CPU_NONE),
     DEFINE_PROP_BOOL("force-raw", GenericLoaderState, force_raw, false),
+    DEFINE_PROP_STRING("reg",GenericLoaderState, reg),
     DEFINE_PROP_STRING("file", GenericLoaderState, file),
     DEFINE_PROP_UINT16("attrs-requester-id", GenericLoaderState,
                        attrs.requester_id, 0),

--- a/include/hw/core/generic-loader.h
+++ b/include/hw/core/generic-loader.h
@@ -35,7 +35,7 @@ struct GenericLoaderState {
     uint32_t cpu_num;
 
     char *file;
-
+    char *reg;
     bool force_raw;
     bool data_be;
     bool set_pc;
@@ -45,6 +45,10 @@ struct GenericLoaderState {
         bool debug;
         uint16_t requester_id;
     } attrs;
+
+     // Add an array for storing default register values
+    bool has_register_defaults[31];  // Track if a default value is provided
+    uint64_t register_defaults[31];  // Default values for registers r0-r30
 };
 
 #define TYPE_GENERIC_LOADER "loader"


### PR DESCRIPTION
I need to set a register on startup to mimic what uboot would do.

Command line option allows me to do this without having to load into gdb.

```
-device loader,reg=r5,data=0xc0001000,data-len=4
```