### PR TITLE
Fixing compatibility with glibc 2.41. sched_attr struct isn't defined…

### DIFF
--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -359,19 +359,23 @@ _syscall3(int, sys_sched_getaffinity, pid_t, pid, unsigned int, len,
 #define __NR_sys_sched_setaffinity __NR_sched_setaffinity
 _syscall3(int, sys_sched_setaffinity, pid_t, pid, unsigned int, len,
           unsigned long *, user_mask_ptr);
-/* sched_attr is not defined in glibc */
-struct sched_attr {
-    uint32_t size;
-    uint32_t sched_policy;
-    uint64_t sched_flags;
-    int32_t sched_nice;
-    uint32_t sched_priority;
-    uint64_t sched_runtime;
-    uint64_t sched_deadline;
-    uint64_t sched_period;
-    uint32_t sched_util_min;
-    uint32_t sched_util_max;
-};
+          
+// /* sched_attr is not defined in glibc */
+#if (__GLIBC__ == 2) && (__GLIBC_MINOR__ < 41)
+ struct sched_attr {
+     uint32_t size;
+     uint32_t sched_policy;
+     uint64_t sched_flags;
+     int32_t sched_nice;
+     uint32_t sched_priority;
+     uint64_t sched_runtime;
+     uint64_t sched_deadline;
+     uint64_t sched_period;
+     uint32_t sched_util_min;
+     uint32_t sched_util_max;
+ };
+#endif
+
 #define __NR_sys_sched_getattr __NR_sched_getattr
 _syscall4(int, sys_sched_getattr, pid_t, pid, struct sched_attr *, attr,
           unsigned int, size, unsigned int, flags);


### PR DESCRIPTION
… there (sic), when including the headers, apparently it shows up. With redefinition warning interpreted as error, the problem shows up.