### PR TITLE
Fixed submodule paths for roms/u-boot and roms/u-boot-sam460ex 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = https://gitlab.com/qemu-project/qemu-palcode.git
 [submodule "roms/u-boot"]
 	path = roms/u-boot
-	url = https://gitlab.com/qemu-project/u-boot.git
+	url = https://gitlab.com/qemu-project-mirrors/u-boot.git
 [submodule "roms/skiboot"]
 	path = roms/skiboot
 	url = https://gitlab.com/qemu-project/skiboot.git
@@ -27,7 +27,7 @@
 	url = https://gitlab.com/qemu-project/seabios-hppa.git
 [submodule "roms/u-boot-sam460ex"]
 	path = roms/u-boot-sam460ex
-	url = https://gitlab.com/qemu-project/u-boot-sam460ex.git
+	url = https://gitlab.com/qemu-project-mirrors/u-boot-sam460ex.git
 [submodule "roms/edk2"]
 	path = roms/edk2
 	url = https://gitlab.com/qemu-project/edk2.git


### PR DESCRIPTION
# Bugfixes in submodule references

There are two submodules which have now different upstream addresses.

This caused yocto build errors in fetching submodules.

```
WARNING: qemu-xilinx-native-8.2.7+git-r0 do_fetch: Failed to fetch URL gitsm://gitlab.com/qemu-project/u-boot.git;protocol=https;name=roms/u-boot;subpath=roms/u-boot;nobranch=1;lfs=True;bareclone=1;nobranch=1, attempting MIRRORS if available
```


## Before

* https://gitlab.com/qemu-project/u-boot.git
* https://gitlab.com/qemu-project/u-boot-sam460ex.git

```
[submodule "roms/u-boot"]
	path = roms/u-boot
	url = https://gitlab.com/qemu-project/u-boot.git

[submodule "roms/u-boot-sam460ex"]
	path = roms/u-boot-sam460ex
	url = https://gitlab.com/qemu-project/u-boot-sam460ex.git
```

## Updated

* https://gitlab.com/qemu-project-mirrors/u-boot.git
* https://gitlab.com/qemu-project-mirrors/u-boot-sam460ex.git

